### PR TITLE
Feat/database: 최근 뉴스 api 요청 로직 수정, 모바일 캐러셀 사진 크기 조정

### DIFF
--- a/src/components/news/NewsMain.tsx
+++ b/src/components/news/NewsMain.tsx
@@ -283,7 +283,7 @@ const CarouselPreview = styled.img<Props>`
   background-position: center;
   @media screen and (max-width: 990px) {
     width: 100%;
-    height: 100%;
+    height: 30vh;
   }
 `;
 

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -19,8 +19,13 @@ const News = () => {
       try {
         const allNewsData = await getNews();
         setAllNews(allNewsData);
-        const recentNewsData = await getLatestNews();
-        setRecentNews(recentNewsData);
+        if (!recentNews.length) {
+          const recentNewsData = await getLatestNews();
+          setRecentNews(recentNewsData);
+          console.log('데이터가져옴');
+        } else {
+          console.log('가져올 데이터 없음!');
+        }
       } catch (error) {
         console.error('데이터 가져오기 오류:', error);
       }


### PR DESCRIPTION
## 작업내용

- 모바일 환경에서의 캐러셀 부분 사진 크기 조정
- 뉴스 페이지 진입 시 지속적으로 최근 뉴스를 불러오는 로직 수정
<br>

## 주요 변경점

- 사진 크기 30vh로 조정
- 배열의 길이를 통해 로직 제어
<br>

## 유의할 점 (optional)

- 팀원이 유의해야할 변경 사항이나 로직이 생겼다면 적어주세요.
<br>

## To Reviewers (optional)

- 확인 후 머지 부탁드립니다!
