### PR TITLE
refact/etc: 메인페이지 뉴스 더보기 버튼 UI 변경

### DIFF
--- a/src/components/database/DatabaseSidebar.tsx
+++ b/src/components/database/DatabaseSidebar.tsx
@@ -38,19 +38,8 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   min-width: 300px;
-  width: 20%;
+  width: 30%;
   height: auto;
   box-sizing: border-box;
   padding: 3rem;
-`;
-
-const Menu = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  color: gray;
-  text-decoration: none;
-  font-size: 1.2rem;
-  padding: 0.5rem;
-  cursor: pointer;
 `;

--- a/src/components/database/DatabaseToggleMenu.tsx
+++ b/src/components/database/DatabaseToggleMenu.tsx
@@ -55,7 +55,7 @@ const Wrapper = styled.div`
   text-decoration: none;
   color: gray;
   font-size: 1.2rem;
-  padding: 0.5rem;
+  padding: 0.8rem 0.5rem;
   cursor: pointer;
 `;
 

--- a/src/components/game/GameSidebar.tsx
+++ b/src/components/game/GameSidebar.tsx
@@ -62,7 +62,8 @@ export default SideBar;
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  width: 20%;
+  min-width: 300px;
+  width: 30%;
   height: auto;
   box-sizing: border-box;
   padding: 3rem;
@@ -73,7 +74,7 @@ const Container = styled.div`
     flex-direction: column;
     background-color: white;
     width: 100%;
-    min-height: 100vh;
+    min-height: 1000px;
     left: -100%;
     box-sizing: border-box;
     padding: 3rem;
@@ -93,7 +94,7 @@ const ToggleMenu = styled.div`
   text-decoration: none;
   color: gray;
   font-size: 1.2rem;
-  padding: 0.5rem;
+  padding: 0.8rem 0.5rem;
   cursor: pointer;
 
   @media screen and (max-width: 990px) {
@@ -129,6 +130,7 @@ const SubMenu = styled(Link)<Props>`
   color: ${props => (props.focus === props.url ? 'black' : 'gray')};
   font-size: 1rem;
   text-decoration: none;
+  padding: 0.5rem;
   @media screen and (max-width: 990px) {
     font-size: 0.8rem;
   }

--- a/src/components/guide/GuideSidebar.tsx
+++ b/src/components/guide/GuideSidebar.tsx
@@ -58,7 +58,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   min-width: 300px;
-  width: 20%;
+  width: 30%;
   height: auto;
   box-sizing: border-box;
   padding: 3rem;
@@ -71,7 +71,7 @@ const Container = styled.div`
     flex-direction: column;
     background-color: white;
     width: 100%;
-    min-height: 100vh;
+    min-height: 1000px;
     left: -100%;
     box-sizing: border-box;
     padding: 3rem;

--- a/src/components/guide/ToggleMenu.tsx
+++ b/src/components/guide/ToggleMenu.tsx
@@ -67,7 +67,7 @@ const Wrapper = styled.div`
   text-decoration: none;
   color: gray;
   font-size: 1.2rem;
-  padding: 0.5rem;
+  padding: 0.8rem 0.5rem;
   cursor: pointer;
 
   @media screen and (max-width: 990px) {
@@ -90,7 +90,7 @@ const InnerContaianer = styled.div<Props>`
 
 const Submenu = styled(Link)<Props>`
   margin-left: 1rem;
-  padding: 0.2rem 0.5rem;
+  padding: 0.5rem;
   border-left: 1px solid gray;
   color: ${props => (props.focus ? 'black' : 'gray')};
   font-size: 1rem;

--- a/src/components/home/SectionNews.tsx
+++ b/src/components/home/SectionNews.tsx
@@ -130,11 +130,22 @@ const GoToNews = styled.div`
 `;
 
 const Button = styled.span`
-  width: 156px;
+  min-width: 156px;
+  width: auto;
+  padding: 1rem;
   font-weight: 700;
   font-size: 1rem;
   text-align: center;
   cursor: pointer;
+
+  @media screen and (max-width: 990px) {
+    border-radius: 5px;
+    background: linear-gradient(90deg, rgba(104, 195, 196, 0.5) 0%, rgba(0, 31, 169, 0.5) 100%);
+    color: #ffffff;
+    &:hover {
+      background: linear-gradient(90deg, #68c3c4 0%, #001fa9 100%);
+    }
+  }
 `;
 
 const Boundary = styled(BoundaryIcon)`
@@ -145,4 +156,7 @@ const Boundary = styled(BoundaryIcon)`
 `;
 const Dot = styled(DotIcon)`
   margin: 0.5rem;
+  @media screen and (max-width: 990px) {
+    display: none;
+  }
 `;


### PR DESCRIPTION
## 작업내용

- 메인페이지 뉴스 더보기 버튼 UI 변경
<br>

## 주요 변경점

- 더보기 버튼 너비 조정
- 모바일 반응형 추가
<br>

## 유의할 점 (optional)

- 모바일 전환 시, 뉴스 페이지의 버튼과 공통 디자인으로 적용했습니다
<br>

## To Reviewers (optional)

- 
