### PR TITLE
Feat/titleChecker: 타이틀 중복체크 api 추가

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -129,8 +129,9 @@ export const getDatabaseContent = async (title: string | undefined) => {
   const response = await axios.get(`${SERVER_URL}/api/getDatabaseContents`, {
     params: {title},
   });
+};
 
 export const isValidTitle = async (collection: string, title: string) => {
   const response = await axios.post(`${SERVER_URL}/api/titleChecker`, {title: title, collection: collection});
-return response.data;
+  return response.data;
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -119,3 +119,8 @@ export const getGuideList = async () => {
   const response = await axios.get(`${SERVER_URL}/api/getGuideList`);
   return response.data;
 };
+
+export const isValidTitle = async (collection: string, title: string) => {
+  const response = await axios.post(`${SERVER_URL}/api/titleChecker`, {title: title, collection: collection});
+  return response.data;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -129,6 +129,7 @@ export const getDatabaseContent = async (title: string | undefined) => {
   const response = await axios.get(`${SERVER_URL}/api/getDatabaseContents`, {
     params: {title},
   });
+  return response.data;
 };
 
 export const isValidTitle = async (collection: string, title: string) => {

--- a/src/components/database/DatabaseContent.tsx
+++ b/src/components/database/DatabaseContent.tsx
@@ -21,7 +21,7 @@ const DatabaseContent = () => {
   const [title, setTitle] = useState('');
   const [text, setText] = useState('');
   const navigate = useNavigate();
-  const data = useQuery({
+  const {data} = useQuery({
     queryKey: [`${id}`],
     queryFn: async () => {
       return await getDatabaseContent(id);
@@ -35,18 +35,19 @@ const DatabaseContent = () => {
   };
 
   useEffect(() => {
-    if (id === undefined && data.data) {
-      setTitle(data.data?.title);
-      setText(data.data?.content);
+    if (id === undefined && data) {
+      setTitle(data?.title);
+      setText(data?.content);
+      console.log(data);
     }
   }, []);
 
   useEffect(() => {
-    if (data.data) {
-      setTitle(data.data?.title);
-      setText(data.data?.content);
+    if (data) {
+      setTitle(data?.title);
+      setText(data?.content);
     }
-  }, [data.data]);
+  }, [data]);
 
   return (
     <Container>

--- a/src/pages/Guide.tsx
+++ b/src/pages/Guide.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import {useEffect} from 'react';
-import {getGuideData, getGuideList} from '../api';
+import {getGuideList} from '../api';
 import {guideData, guideList} from '../states/atoms';
 import {useRecoilState} from 'recoil';
 import Intro from '../components/Intro';
@@ -10,7 +10,6 @@ import GuideContent from '../components/guide/GuideContent';
 import TopScrollButton from '../components/TopScrollButton';
 import OpenMobileNav from '../components/OpenMobileNav';
 import {isMobileNavOpen} from '../states/atoms';
-import {useQuery} from '@tanstack/react-query';
 
 const Guide = () => {
   const [textData, setTextData] = useRecoilState(guideData);

--- a/src/pages/PostGuides.tsx
+++ b/src/pages/PostGuides.tsx
@@ -4,7 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import {FileDrop} from 'react-file-drop';
-import {uploadImage, uploadGuide} from '../api';
+import {uploadImage, uploadGuide, isValidTitle} from '../api';
 import {useNavigate} from 'react-router';
 import '../styles/markdown.css';
 
@@ -37,9 +37,14 @@ const PostGuides = () => {
     setContent(e.target.value);
   };
 
-  const submit = () => {
-    uploadGuide({category, title, content});
-    navigate('/');
+  const submit = async () => {
+    const isTitlevalid = await isValidTitle('guide', title);
+    if (isTitlevalid) {
+      uploadGuide({category, title, content});
+      navigate('/');
+    } else {
+      alert('중복된 제목이니 다른 제목을 쓰라우.');
+    }
   };
 
   return (


### PR DESCRIPTION
## 작업내용

- 타이틀 중복체크 api 추가
<br>

## 주요 변경점

- 타이틀 중복체크 api 추가
- 가이드, 데이터베이스 글 추가/삭제 시 제목 유효성 체크하는 로직 추가
<br>

## 유의할 점 (optional)

- 매개변수 안에 체크할 글의 제목이 들어갈 콜렉션과, 글제목을 전달하면 됩니다.
<br>

## To Reviewers (optional)

- 
