### PR TITLE
Refact/news: 뉴스 상세페이지 로직 수정

### DIFF
--- a/src/components/home/NewsCard.tsx
+++ b/src/components/home/NewsCard.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 import {useNavigate} from 'react-router';
+import {useRecoilValue} from 'recoil';
+import {recentNewsState} from '../../states/atoms';
 
 interface Props {
   thumbnail: string;
@@ -14,7 +16,7 @@ const NewsCard = ({thumbnail, category, title, outline, date, id}: Props) => {
   return (
     <NewsContainer
       onClick={() => {
-        navigate(`/news/${String(id)}`);
+        navigate(`/news/${id}`);
       }}
     >
       <NewsImage

--- a/src/components/home/SectionNews.tsx
+++ b/src/components/home/SectionNews.tsx
@@ -7,10 +7,8 @@ import {useRecoilValue} from 'recoil';
 import {recentNewsState} from '../../states/atoms';
 
 const SectionNews = () => {
-  const recentNews = useRecoilValue(recentNewsState);
-
   let navigate = useNavigate();
-
+  const recentNews = useRecoilValue(recentNewsState);
   const goToNews = () => {
     navigate('/news');
   };

--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -4,7 +4,6 @@ import {postLastNewsIndex} from '../../api';
 import {allNewsState} from '../../states/atoms';
 import {useRecoilState} from 'recoil';
 import {useNavigate} from 'react-router';
-
 const NewsList = () => {
   const [allNews, setAllNews] = useRecoilState(allNewsState) as any[];
   const [len, setLen] = useState(allNews.length);

--- a/src/components/news/NewsMain.tsx
+++ b/src/components/news/NewsMain.tsx
@@ -84,10 +84,6 @@ const NewsMain = () => {
     setIntervalCheck(intervalCheck);
   };
 
-  const TestFunc = () => {
-    console.log('clicked');
-  };
-
   return (
     <>
       <Container>
@@ -125,7 +121,7 @@ const NewsMain = () => {
                       navigate(`/news/${element.id}`);
                     }}
                   >
-                    <CarouselPreview src={element.thumbnail} onClick={TestFunc}></CarouselPreview>
+                    <CarouselPreview src={element.thumbnail}></CarouselPreview>
                     <CarouselImageBorder></CarouselImageBorder>
                   </CarouselImageContainer>
                 </CarouselContainer>

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,6 +1,6 @@
 export const PUBLIC_PATH = process.env.PUBLIC_URL;
-// export const SERVER_URL = 'http://localhost:8080';
-export const SERVER_URL = 'https://port-0-blue-protocol-server-4fju66f2clmzty3z1.sel5.cloudtype.app';
+export const SERVER_URL = 'http://localhost:8080';
+// export const SERVER_URL = 'https://port-0-blue-protocol-server-4fju66f2clmzty3z1.sel5.cloudtype.app';
 export const OFFICIAL_URL = 'https://blueprotocol.game.onstove.com';
 export const DISCORD_URL = 'https://discord.gg/p6ruJWERbH';
 export const KAKAO_URL = 'https://open.kakao.com/o/g4OwxAOe';

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,6 +1,6 @@
 export const PUBLIC_PATH = process.env.PUBLIC_URL;
-export const SERVER_URL = 'http://localhost:8080';
-// export const SERVER_URL = 'https://port-0-blue-protocol-server-4fju66f2clmzty3z1.sel5.cloudtype.app';
+// export const SERVER_URL = 'http://localhost:8080';
+export const SERVER_URL = 'https://port-0-blue-protocol-server-4fju66f2clmzty3z1.sel5.cloudtype.app';
 export const OFFICIAL_URL = 'https://blueprotocol.game.onstove.com';
 export const DISCORD_URL = 'https://discord.gg/p6ruJWERbH';
 export const KAKAO_URL = 'https://open.kakao.com/o/g4OwxAOe';

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,24 +3,23 @@ import SectionMain from '../components/home/SectionMain';
 import SectionNews from '../components/home/SectionNews';
 import SectionInfo from '../components/home/SectionInfo';
 import TopScrollButton from '../components/TopScrollButton';
-import {recentNewsState} from '../states/atoms';
+import {allNewsState, recentNewsState} from '../states/atoms';
 import {useRecoilState} from 'recoil';
 import {useEffect} from 'react';
-import {getLatestNews} from '../api';
-
+import {getLatestNews, getNews} from '../api';
 const Home = () => {
   const [recentNews, setRecentNews] = useRecoilState(recentNewsState);
-
   useEffect(() => {
-    const fetchData = async () => {
-      if (!recentNews.length) {
+    async function fetchData() {
+      try {
         const recentNewsData = await getLatestNews();
         setRecentNews(recentNewsData);
         console.log('데이터가져옴');
-      } else {
-        console.log('가져올 데이터 없음!');
+      } catch (error) {
+        console.error('데이터 가져오기 오류:', error);
       }
-    };
+    }
+
     fetchData();
   }, []);
 

--- a/src/pages/NewsDetail.tsx
+++ b/src/pages/NewsDetail.tsx
@@ -1,12 +1,12 @@
-import {useEffect, useState} from 'react';
+import {SetStateAction, useEffect, useState} from 'react';
 import {useParams, useNavigate} from 'react-router';
 import styled from 'styled-components';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import {useRecoilValue} from 'recoil';
-import {allNewsState, loginState} from '../states/atoms';
-import {deleteNews} from '../api';
+import {allNewsState, loginState, recentNewsState} from '../states/atoms';
+import {deleteNews, getNews} from '../api';
 import AdminButton from '../components/AdminButton';
 import '../styles/markdown.css';
 
@@ -26,16 +26,38 @@ function NewsDetail() {
   const [selectNews, setSelectNews] = useState<NewsProps>();
   const allNews = useRecoilValue(allNewsState);
   const isAdmin = useRecoilValue(loginState);
+  const recentNews = useRecoilValue(recentNewsState);
+  async function fetchData() {
+    try {
+      const allNewsData = await getNews();
+      allNewsData.forEach((element: NewsProps | undefined) => {
+        if (element && Number(id) === element.id) {
+          setSelectNews(element);
+          console.log('실행');
+        }
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  }
 
   useEffect(() => {
-    allNews.forEach(element => {
-      console.log(element);
-      if (Number(id) === element.id) {
-        setSelectNews(element);
-        console.log('실행');
-      }
-    });
-  }, [allNews]);
+    if (allNews.length === 0 && recentNews.length === 0) {
+      fetchData();
+    } else if (allNews.length > 0) {
+      allNews.forEach(element => {
+        if (Number(id) === element.id) {
+          setSelectNews(element);
+        }
+      });
+    } else {
+      recentNews.forEach(element => {
+        if (Number(id) === element.id) {
+          setSelectNews(element);
+        }
+      });
+    }
+  }, [id, allNews, recentNews]);
 
   return (
     <Container>


### PR DESCRIPTION
## 작업내용

- 뉴스 상세페이지 로직 수정
<br>

## 주요 변경점

- 새로고침 시 allNews의 배열과 recentNews의 배열에 비어있다면 allNews에 대한 데이터를 받아오도록 함
- 정해진 포맷대로 접속 시, recentNews에 해당하는 뉴스를 누르면 recentNews만 불러와서 상세페이지 팝업되도록 수정
- 정해진 포맷대로 접속 시, allNews에 해당하는 뉴스를 누르면 allNews를 불러와서 상세페이지 팝업되도록 수정
<br>

## 유의할 점 (optional)

- 팀원이 유의해야할 변경 사항이나 로직이 생겼다면 적어주세요.
<br>

## To Reviewers (optional)

- 확인 후 머지 부탁드립니다!
