### PR TITLE
Feat/logout: 로그아웃 기능 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,8 +6,18 @@ import {ReactComponent as MenuLogo} from '../assets/icons/menu-logo.svg';
 import {ReactComponent as XLogo} from '../assets/icons/x-logo.svg';
 import {ReactComponent as MainLogo} from '../assets/icons/main-logo.svg';
 import SideBar from './Sidebar';
+import AdminButton from './AdminButton';
+import {loginState} from '../states/atoms';
+import {useRecoilState} from 'recoil';
+
 const Header = () => {
   const navigate = useNavigate();
+  const [isAdmin, setIsAdmin] = useRecoilState(loginState);
+  const logOut = () => {
+    localStorage.removeItem('jwt');
+    setIsAdmin(false);
+    navigate('/');
+  };
   const goHome = () => {
     navigate('/');
   };
@@ -41,6 +51,14 @@ const Header = () => {
             <StyledLink to="/database">데이터베이스</StyledLink>
           </Nav>
         </Inner>
+        {isAdmin ? (
+          <LogOutBtn
+            text="로그아웃"
+            onClick={() => {
+              logOut();
+            }}
+          ></LogOutBtn>
+        ) : null}
         <HamburgerContainer>
           {clicked ? (
             <X
@@ -191,3 +209,5 @@ const Main = styled(MainLogo)`
     width: auto;
   }
 `;
+
+const LogOutBtn = styled(AdminButton)``;

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
-import React, {useEffect} from 'react';
+import {useEffect} from 'react';
 import {useRecoilState} from 'recoil';
-import {databaseData, databaseList, isMobileNavOpen} from '../states/atoms';
+import {databaseList, isMobileNavOpen} from '../states/atoms';
 import {getDatabaseList} from '../api';
 import Intro from '../components/Intro';
 import {ReactComponent as DiaIcon} from '../assets/icons/borderIcon.svg';

--- a/src/pages/EditDatabase.tsx
+++ b/src/pages/EditDatabase.tsx
@@ -7,8 +7,6 @@ import {FileDrop} from 'react-file-drop';
 import {uploadImage, updateDatabaseData, getDatabaseContent} from '../api';
 import {useNavigate, useParams} from 'react-router';
 import '../styles/markdown.css';
-import {databaseData, databaseList} from '../states/atoms';
-import {useRecoilState, useRecoilValue} from 'recoil';
 import {useQuery} from '@tanstack/react-query';
 
 const EditDatabase = () => {

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import styled from 'styled-components';
 import GameSideBar from '../components/game/GameSidebar';
 import Content from '../components/game/Content';

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,10 +3,11 @@ import SectionMain from '../components/home/SectionMain';
 import SectionNews from '../components/home/SectionNews';
 import SectionInfo from '../components/home/SectionInfo';
 import TopScrollButton from '../components/TopScrollButton';
-import {allNewsState, recentNewsState} from '../states/atoms';
+import {recentNewsState} from '../states/atoms';
 import {useRecoilState} from 'recoil';
 import {useEffect} from 'react';
-import {getLatestNews, getNews} from '../api';
+import {getLatestNews} from '../api';
+
 const Home = () => {
   const [recentNews, setRecentNews] = useRecoilState(recentNewsState);
   useEffect(() => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,8 +1,8 @@
-import styled, {useTheme} from 'styled-components';
+import styled from 'styled-components';
 import {submitLogin} from '../api/auth';
 import {useState} from 'react';
 import {useNavigate} from 'react-router';
-import {useRecoilState, useRecoilValue} from 'recoil';
+import {useRecoilState} from 'recoil';
 import {loginState} from '../states/atoms';
 
 const Login = () => {


### PR DESCRIPTION
## 작업내용

- 로그아웃 기능 구현
<br>

## 주요 변경점

- 관리자 로그아웃 기능 구현
- 관리자 로그인 시 헤더에 로그아웃 버튼 노출
- 로그아웃 버튼 클릭 시, 로그인 전역상태 해제 및 JWT 토큰 삭제
<br>

## 유의할 점 (optional)

- 그 외 페이지 컴포넌트 내 사용하지 않는 모듈 삭제해줬습니다.
<br>

## To Reviewers (optional)

- 리뷰어에게 부탁할 내용(ex.~부분 도움 부탁합니다, ~부분 한 번 더 검토 부탁드려요) 이 있다면 적어주세요.
